### PR TITLE
Add handling for SystemD based init

### DIFF
--- a/etcd/files/etcd.service.jinja
+++ b/etcd/files/etcd.service.jinja
@@ -1,0 +1,24 @@
+{% from "etcd/map.jinja" import etcd_settings with context -%}
+[Unit]
+Description=etcd {{ etcd_settings.install.version }} - highly-available key value store
+Documentation=https://github.com/coreos/etcd
+Documentation=man:etcd
+After=network.target
+Wants=network-online.target
+
+[Service]
+Environment=DAEMON_ARGS=
+Environment=ETCD_NAME=%H
+Environment=ETCD_DATA_DIR={{ etcd_settings.data_directory }}
+EnvironmentFile=-/etc/default/%p
+StandardOutput=syslog
+WorkingDirectory={{ etcd_settings.data_directory }}
+#ExecStart=/bin/sh -c "GOMAXPROCS=$(nproc) /usr/bin/etcd $DAEMON_ARGS"
+ExecStart={{ etcd_settings.binary_directory }}/etcd $DAEMON_ARGS
+Restart=on-abnormal
+#RestartSec=10s
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target
+Alias=etcd2.service

--- a/etcd/install.sls
+++ b/etcd/install.sls
@@ -36,7 +36,7 @@ etcd-systemd-file:
     - source: salt://etcd/files/etcd.service.jinja
     - user: root
     - group: root
-    - mode: 0755
+    - mode: 0644
     - template: jinja
     - watch_in:
         service: etcd-service

--- a/etcd/map.jinja
+++ b/etcd/map.jinja
@@ -3,7 +3,7 @@
 
 {## Start with defaults from defaults.yaml ##}
 {% import_yaml "etcd/defaults.yaml" as default_settings %}
-
+{% set systemd = salt['grains.has_value']('systemd')|default(False) -%}
 {# Update settings defaults from pillar data #}
 {% set etcd_settings = salt['pillar.get'](
     'etcd',


### PR DESCRIPTION
Added simple handling to for systemd based init.  Use a grain to check for systemd present, and then install that.  etcd.service based on Debian 'stretch' version, but does not use separate etcd user account.
