### PR TITLE
updated default version & fix indentation

### DIFF
--- a/etcd/defaults.yaml
+++ b/etcd/defaults.yaml
@@ -6,11 +6,14 @@ etcd:
   data_directory: /opt/etcd/data
 
   cluster:
-    token: my-etcd-cluster
-    peer_port: 2380
     client_port: 2379
+    peer_port: 2380
+    peers:
+      node-1:
+        ip: 127.0.0.1
+    token: my-etcd-cluster
   
   install:
     base_url: http://github.com/coreos/etcd/releases/download
-    version: 2.1.2
+    version: 3.2.18
 

--- a/pillar.example
+++ b/pillar.example
@@ -2,8 +2,10 @@
 
 # Right now, only static configuration is supported
 etcd:
-   cluster:
-     peers:
-       node-1: 
-         ip: 192.168.1.10
+  install:
+    version: 3.3.3
+  cluster:
+    peers:
+      node-1:
+        ip: 192.168.1.10
        


### PR DESCRIPTION
PR updating few small things.
- default release value
- default in alphabetical order
- default host 127.0.0.1
- Fix bad indentation in pillar.example.