### PR TITLE
rename 'service' parameter

### DIFF
--- a/etcd/defaults.yaml
+++ b/etcd/defaults.yaml
@@ -20,7 +20,7 @@ etcd:
     #linux
     group: etcd
     realhome: /usr/local/coreos/etcd-v2.1.2-linux-amd64
-    service: etcd
+    service_name: etcd
     src_hashsum:
     src_hashurl:
     symhome: /opt/etcd

--- a/etcd/install.sls
+++ b/etcd/install.sls
@@ -90,7 +90,7 @@ etcd-install:
     - archive_format: {{ etcd.dl.format.split('.')[0] }}
     - unless: test -f {{ etcd.lookup.realhome }}{{ etcd.lookup.command }}
     - watch_in:
-      - service: etcd_{{ etcd.lookup.service }}_running
+      - service: etcd_{{ etcd.lookup.service_name }}_running
     - onchanges:
       - cmd: etcd-download-archive
     {%- if etcd.lookup.src_hashurl and grains['saltversioninfo'] > [2016, 11, 6] %}

--- a/etcd/service.sls
+++ b/etcd/service.sls
@@ -6,17 +6,17 @@
 
 etcd-launchd:
   file.managed:
-    - name: /Library/LaunchAgents/{{ etcd.lookup.service }}.plist
-    - source: /usr/local/opt/etcd/{{ etcd.lookup.service }}.plist
+    - name: /Library/LaunchAgents/{{ etcd.lookup.service_name }}.plist
+    - source: /usr/local/opt/etcd/{{ etcd.lookup.service_name }}.plist
     - group: wheel
     - watch_in:
-      - etcd_{{ etcd.lookup.service }}_running
+      - etcd_{{ etcd.lookup.service_name }}_running
 
 {% elif grains.init == 'systemd' %}
 
 etcd-systemd:
   file.managed:
-    - name: '/etc/systemd/system/{{ etcd.lookup.service }}.service'
+    - name: '/etc/systemd/system/{{ etcd.lookup.service_name }}.service'
     - source: 'salt://etcd/files/systemd.service.jinja'
     - user: root
     - group: root
@@ -31,13 +31,13 @@ etcd-systemd:
     - require:
       - file: etcd-systemd
     - require_in:
-      - service:  etcd_{{ etcd.lookup.service }}_running
+      - service:  etcd_{{ etcd.lookup.service_name }}_running
 
 {% elif grains.init  == 'upstart' %}
 
 etcd-service:
   file.managed:
-    - name: '/etc/init/{{ etcd.lookup.service }}.conf'
+    - name: '/etc/init/{{ etcd.lookup.service_name }}.conf'
     - source: 'salt://etcd/files/upstart.service.jinja'
     - user: root
     - group: root
@@ -46,13 +46,13 @@ etcd-service:
     - context:
       etcd: {{ etcd|json }}
     - require_in:
-      - service:  etcd_{{ etcd.lookup.service }}_running 
+      - service:  etcd_{{ etcd.lookup.service_name }}_running
 
 {% endif %}
 
-etcd_{{ etcd.lookup.service }}_running:
+etcd_{{ etcd.lookup.service_name }}_running:
   service.running:
-    - name: {{ etcd.lookup.service }}
+    - name: {{ etcd.lookup.service_name }}
     - enable: {{ etcd.lookup.service_enabled }}
     # todo: add launchd service for non-homebrew installs on MacOS
     - unless: test "`uname`" = "Darwin" && "{{ etcd.lookup.use_upstream_repo|lower }}" ==  "true"


### PR DESCRIPTION
This PR removes confusion between similar named `etcd.lookup.service` and `etcd.service`.