### PR TITLE
Removed unused 'lookup' dict

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Metastate for all deployment states.
 
 ``etcd.install``
 ------------
-Installs etcd version by downloading the archive from github and extracting it to the {{ etcd.lookup.prefix }} directory.
+Installs etcd version by downloading the archive from github and extracting it to the {{ etcd.prefix }} directory.
 
 ``etcd.service``
 ------------

--- a/etcd/defaults.yaml
+++ b/etcd/defaults.yaml
@@ -2,30 +2,29 @@
 # vim: ft=yaml
 
 etcd:
-  lookup:
-    #windows/linu/darwin
-    arch: amd64
-    pkg:
-    service_enabled: true
-    version: 3.2.18
-    #linux/darwin
-    bakdir: /tmp/etcd_backup/
-    command: etcd
-    datadir: /var/lib/etcd/
-    prefix: /usr/local/coreos
-    logdir: /var/log/etcd/
-    manage_users: true
-    os: linux
-    tmpdir: /tmp/coreostmp/
-    #linux
-    group: etcd
-    realhome: /usr/local/coreos/etcd-v2.1.2-linux-amd64
-    service_name: etcd
-    src_hashsum:
-    src_hashurl:
-    symhome: /opt/etcd
-    user: etcd
-    use_upstream_repo: true
+  #windows/linu/darwin
+  arch: amd64
+  pkg:
+  service_enabled: true
+  version: 3.2.18
+  #linux/darwin
+  bakdir: /tmp/etcd_backup/
+  command: etcd
+  datadir: /var/lib/etcd/
+  prefix: /usr/local/coreos
+  logdir: /var/log/etcd/
+  manage_users: true
+  os: linux
+  tmpdir: /tmp/coreostmp/
+  #linux
+  group: etcd
+  realhome: /usr/local/coreos/etcd-v2.1.2-linux-amd64
+  service_name: etcd
+  src_hashsum:
+  src_hashurl:
+  symhome: /opt/etcd
+  user: etcd
+  use_upstream_repo: true
 
   dl:
     archive_name:

--- a/etcd/files/env4etcd.sh
+++ b/etcd/files/env4etcd.sh
@@ -1,4 +1,4 @@
-{% for key,value in etcd.lookup.items() -%}
+{% for key,value in etcd.service.items() -%}
 export ETCD_{{ key|string|upper }}={{ "value" or "" }}
 {% endfor %}
 
@@ -6,5 +6,5 @@ export ETCD_{{ key|string|upper }}={{ "value" or "" }}
 export ETCDCTL_{{ key|string|upper }}={{ "value" or "" }}
 {% endfor %}
 
-export ETCD_HOME={{ etcd.lookup.realhome }}
+export ETCD_HOME={{ etcd.realhome }}
 export PATH=${PATH}:${ETCD_HOME}

--- a/etcd/files/etcd.sh
+++ b/etcd/files/etcd.sh
@@ -1,2 +1,2 @@
-export ETCD_HOME={{ etcd.lookup.realhome }}
+export ETCD_HOME={{ etcd.realhome }}
 export PATH=${PATH}:${ETCD_HOME}

--- a/etcd/files/systemd.service.jinja
+++ b/etcd/files/systemd.service.jinja
@@ -14,11 +14,11 @@ Environment='ETCD_{{ key|string|upper }}={{ value or "" }}'
 Environment='ETCDCTL_{{ key|string|upper }}={{ value or "" }}'
 {% endfor %}
 
-ExecStart={{ etcd.lookup.realhome }}/etcd
+ExecStart={{ etcd.realhome }}/etcd
 Restart=always
 RestartSec=10s
 LimitNOFILE=40000
-WorkingDirectory={{ etcd.lookup.datadir }}
+WorkingDirectory={{ etcd.datadir }}
 
 [Install]
 WantedBy=multi-user.target

--- a/etcd/files/upstart.service.jinja
+++ b/etcd/files/upstart.service.jinja
@@ -1,4 +1,4 @@
-description "etcd {{ etcd.lookup.version }} distributed key-value store"
+description "etcd {{ etcd.version }} distributed key-value store"
 author "Robert Fach <robert.fach@gmx.net>"
 
 start on (net-device-up
@@ -9,12 +9,12 @@ stop on runlevel [016]
 respawn
 respawn limit 10 5
 
-{% for key,value in etcd.lookup.items() -%}
+{% for key,value in etcd.items() -%}
 env ETCD_{{ key|string|upper }}='{{ value or "" }}'
 {% endfor %}
 {% for key,value in etcd.etcdctl.items() -%}
 env ETCDCTL_{{ key|string|upper }}='{{ value or "" }}'
 {% endfor %}
 
-chdir {{ etcd.lookup.datadir }}
-exec {{ etcd.lookup.realhome }}/etcd >>{{ etcd.lookup.logdir }}/etcd.log 2>&1
+chdir {{ etcd.datadir }}
+exec {{ etcd.realhome }}/etcd >>{{ etcd.logdir }}/etcd.log 2>&1

--- a/etcd/init.sls
+++ b/etcd/init.sls
@@ -8,16 +8,16 @@ include:
   - etcd.linuxenv
 
 extend:
-  etcd_{{ etcd.lookup.service }}_running:
+  etcd_{{ etcd.service }}_running:
     service:
       - listen:
-           {% if etcd.lookup.use_upstream_repo|lower == 'homebrew' %}
+           {% if etcd.use_upstream_repo|lower == 'homebrew' %}
         - file: etcd-install
            {% else %}
         - archive: etcd-install
            {% endif %}
       - require:
-           {% if etcd.lookup.use_upstream_repo|lower == 'homebrew' %}
+           {% if etcd.use_upstream_repo|lower == 'homebrew' %}
         - file: etcd-install
            {% else %}
         - archive: etcd-install

--- a/etcd/linuxenv.sls
+++ b/etcd/linuxenv.sls
@@ -4,9 +4,9 @@
 
 etcd-home-symlink:
   file.symlink:
-    - name: '{{ etcd.lookup.symhome }}'
-    - target: '{{ etcd.lookup.realhome }}'
-    - onlyif: test -d {{ etcd.lookup.realhome }}
+    - name: '{{ etcd.symhome }}'
+    - target: '{{ etcd.realhome }}'
+    - onlyif: test -d {{ etcd.realhome }}
     - force: True
 
 # Update system profile with PATH
@@ -29,14 +29,14 @@ etcd-config:
 etcd-home-alt-install:
   alternatives.install:
     - name: etcd-home
-    - link: '{{ etcd.lookup.symhome }}'
-    - path: '{{ etcd.lookup.realhome }}'
+    - link: '{{ etcd.symhome }}'
+    - path: '{{ etcd.realhome }}'
     - priority: {{ etcd.linux.altpriority }}
 
 etcd-home-alt-set:
   alternatives.set:
     - name: etcd-home
-    - path: {{ etcd.lookup.realhome }}
+    - path: {{ etcd.realhome }}
     - onchanges:
       - alternatives: etcd-home-alt-install
 
@@ -45,7 +45,7 @@ etcd-alt-install:
   alternatives.install:
     - name: etcd
     - link: {{ etcd.linux.symlink }}
-    - path: {{ etcd.lookup.realhome }}/etcd
+    - path: {{ etcd.realhome }}/etcd
     - priority: {{ etcd.linux.altpriority }}
     - require:
       - alternatives: etcd-home-alt-install
@@ -54,7 +54,7 @@ etcd-alt-install:
 etcd-alt-set:
   alternatives.set:
     - name: etcd
-    - path: {{ etcd.lookup.realhome }}/etcd
+    - path: {{ etcd.realhome }}/etcd
     - onchanges:
       - alternatives: etcd-alt-install
 

--- a/etcd/map.jinja
+++ b/etcd/map.jinja
@@ -3,7 +3,7 @@
 {% import_yaml 'etcd/defaults.yaml' as defaults %}
 {% import_yaml "etcd/osmap.yaml" as osmap %}
 
-# start with lookup defaults, merge osmap, then pillar data
+# start with defaults, merge osmap, then pillar data
 {% set etcd = salt['grains.filter_by'](
     defaults,
     merge=salt['grains.filter_by'](
@@ -15,10 +15,10 @@
 ) %}
 
 # coreos release download values
-{% set pkg = "{0}-v{1}-{2}-{3}".format(etcd.lookup.pkg or 'etcd', etcd.lookup.version, etcd.lookup.os, etcd.lookup.arch) %} 
+{% set pkg = "{0}-v{1}-{2}-{3}".format(etcd.pkg or 'etcd', etcd.version, etcd.os, etcd.arch) %} 
 {% do etcd.dl.update(
-       { 'src_url': "{0}/v{1}/{2}.{3}".format(etcd.dl.base_uri, etcd.lookup.version, pkg, etcd.dl.format),
+       { 'src_url': "{0}/v{1}/{2}.{3}".format(etcd.dl.base_uri, etcd.version, pkg, etcd.dl.format),
          'archive_name': pkg + '.' + etcd.dl.format, 
        })
 %}
-{% do etcd.lookup.update({ 'realhome': "{0}/{1}".format(etcd.lookup.prefix, pkg), 'pkg': pkg, }) %}
+{% do etcd.update({ 'realhome': "{0}/{1}".format(etcd.prefix, pkg), 'pkg': pkg, }) %}

--- a/etcd/osmap.yaml
+++ b/etcd/osmap.yaml
@@ -1,6 +1,6 @@
 
 MacOS:
-  lookup:
+  etcd:
     os: 'darwin'
     pkg:
     src_hashsum:
@@ -10,8 +10,8 @@ MacOS:
     format: zip
 
 Windows:
-  lookup:
-    bakdir: 'C:\\temp\\lookupbak\\'
+  etcd:
+    bakdir: 'C:\\temp\\etcdbak\\'
     command: 'etcd.exe'
     datadir: 'C:\\Program files\\Coreos\\etcd\\data\\'
     pkg:
@@ -23,6 +23,6 @@ Windows:
     src_hashsum:
     src_hashurl:
     symhome:
-    tmpdir: 'C:\\temp\\lookuptmp\\'
+    tmpdir: 'C:\\temp\\etcdtmp\\'
   dl:
     format: zip

--- a/etcd/service.sls
+++ b/etcd/service.sls
@@ -2,21 +2,21 @@
 # vim: ft=sls
 {% from "etcd/map.jinja" import etcd with context %}
 
-{% if grains.os == 'MacOS' and etcd.lookup.use_upstream_repo|lower == 'homebrew' %}
+{% if grains.os == 'MacOS' and etcd.use_upstream_repo|lower == 'homebrew' %}
 
 etcd-launchd:
   file.managed:
-    - name: /Library/LaunchAgents/{{ etcd.lookup.service_name }}.plist
-    - source: /usr/local/opt/etcd/{{ etcd.lookup.service_name }}.plist
+    - name: /Library/LaunchAgents/{{ etcd.service_name }}.plist
+    - source: /usr/local/opt/etcd/{{ etcd.service_name }}.plist
     - group: wheel
     - watch_in:
-      - etcd_{{ etcd.lookup.service_name }}_running
+      - etcd_{{ etcd.service_name }}_running
 
 {% elif grains.init == 'systemd' %}
 
 etcd-systemd:
   file.managed:
-    - name: '/etc/systemd/system/{{ etcd.lookup.service_name }}.service'
+    - name: '/etc/systemd/system/{{ etcd.service_name }}.service'
     - source: 'salt://etcd/files/systemd.service.jinja'
     - user: root
     - group: root
@@ -31,13 +31,13 @@ etcd-systemd:
     - require:
       - file: etcd-systemd
     - require_in:
-      - service:  etcd_{{ etcd.lookup.service_name }}_running
+      - service:  etcd_{{ etcd.service_name }}_running
 
 {% elif grains.init  == 'upstart' %}
 
 etcd-service:
   file.managed:
-    - name: '/etc/init/{{ etcd.lookup.service_name }}.conf'
+    - name: '/etc/init/{{ etcd.service_name }}.conf'
     - source: 'salt://etcd/files/upstart.service.jinja'
     - user: root
     - group: root
@@ -46,14 +46,14 @@ etcd-service:
     - context:
       etcd: {{ etcd|json }}
     - require_in:
-      - service:  etcd_{{ etcd.lookup.service_name }}_running
+      - service:  etcd_{{ etcd.service_name }}_running
 
 {% endif %}
 
-etcd_{{ etcd.lookup.service_name }}_running:
+etcd_{{ etcd.service_name }}_running:
   service.running:
-    - name: {{ etcd.lookup.service_name }}
-    - enable: {{ etcd.lookup.service_enabled }}
+    - name: {{ etcd.service_name }}
+    - enable: {{ etcd.service_enabled }}
     # todo: add launchd service for non-homebrew installs on MacOS
-    - unless: test "`uname`" = "Darwin" && "{{ etcd.lookup.use_upstream_repo|lower }}" ==  "true"
+    - unless: test "`uname`" = "Darwin" && "{{ etcd.use_upstream_repo|lower }}" ==  "true"
 

--- a/pillar.example
+++ b/pillar.example
@@ -2,13 +2,12 @@
 
 ## Minimal optional configuration
 etcd:
-  lookup:
-    version: 3.2.18
+  version: 3.2.18
 
 ## More optional pillars follow ... (see defaults.yaml)
-    src_hashsum:
-    src_hashurl:
-    #use_upstream_repo: 'homebrew' #not mandatory for MacOS
+  src_hashsum:
+  src_hashurl:
+  #use_upstream_repo: 'homebrew' #not mandatory for MacOS
 
   service:
     name: etcd0


### PR DESCRIPTION
This PR fixes few minor issues:

1. The `lookup` introduced in #7 is superfluous. It should be removed to avoid confusion.
2. The file `etcd/files/env4etcd.sh` should reference `service` not `lookup`
3. The file `osmap.yaml` should reference `C:\\temp\\etcdbak\\` not `lookupbak`.