### PR TITLE
Support for dockerized package/service

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,21 +17,32 @@ Available states
 
 ``etcd``
 ------------
-Metastate for all deployment states.
+Metastate for all the software and service deployment states.
 
 ``etcd.install``
 ------------
 Installs etcd version by downloading the archive from github and extracting it to the {{ etcd.prefix }} directory.
 
-``etcd.service``
-------------
-Configure and (re)start your ETCD service and clusters.
-
 ``etcd.linuxenv``
 ------------
 Configure launchd, systemd, or upstart configuration, this will copy. Setup linux alternatives if enabled and supported.
 
-.. note::
+.. note:: Enable linux alternatives by setting nonzero 'altpriority' pillar value; otherwise feature is disabled.
 
-Enable linux alternatives by setting nonzero 'altpriority' pillar value; otherwise feature is disabled.
+``etcd.service``
+------------
+Ensure the `etcd` service is registered and (re)started on minion.
 
+``etcd.service.stopped``
+------------
+Ensure the `etcd` service is stopped on minion.
+
+``etcd.docker.running``
+------------
+Ensure that an `etcd` container with a specific configuration is present and running. Includes the `etcd.service.stopped` state by default.
+
+.. note:: Requires Docker! Running the `docker` state from the "docker-formula" satisfies this requirement.
+
+``etcd.docker.stopped``
+------------
+Ensure that `etcd` container is stopped

--- a/etcd/defaults.yaml
+++ b/etcd/defaults.yaml
@@ -36,6 +36,19 @@ etcd:
     retries: 1
     unpack_opts: --strip-components=1
 
+  docker:
+    packages: ['python-docker', 'python3-docker',]
+    enabled: false
+    image: quay.io/coreos/etcd
+    version: latest
+    network_mode: host
+    ports:
+      - 127.0.0.1:2379:2379
+      - 127.0.0.1:2380:2380
+    volumes:
+      - /usr/share/ca-certificates/:/etc/ssl/certs
+    stop_etcd_service_first: true
+
   service:
     #defaults for linux
     name: etcd0

--- a/etcd/docker/running.sls
+++ b/etcd/docker/running.sls
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+{% from "etcd/map.jinja" import etcd with context -%}
+
+   {% if etcd.docker.stop_etcd_service_first %}
+include:
+  - etcd.service.stopped
+   {% endif %}
+
+{% for pkg in etcd.docker.packages -%}
+  {% if pkg %}
+etcd-docker-{{ pkg }}-package:
+  pkg.installed:
+    - name:  {{ pkg }}
+    - require_in:
+      - docker_container: run-etcd-dockerized-service
+    - onfail_in:
+      - pip: etcd-docker-python-module
+  {% endif %}
+{% endfor %}
+
+etcd-docker-python-module:
+  pip.installed:
+    - name: 'docker'
+    - reload_modules: True
+    - exists_action: i
+    - force_reinstall: True
+    - require_in:
+      - docker_container: run-etcd-dockerized-service
+
+etcd-ensure-docker-service:
+  service.running:
+    - name: docker
+    - require_in:
+      - docker_container: run-etcd-dockerized-service
+
+run-etcd-dockerized-service:
+  docker_container.running:
+       {% if etcd.docker.version %}
+    - image: {{ etcd.docker.image }}:{{ etcd.docker.version }}
+       {% else %}
+    - image: {{ etcd.docker.image }}
+       {% endif %}
+    - command: {{ etcd.docker.cmd }}
+    - binds:
+        {% for volume in etcd.docker.volumes %}
+      - {{ volume }}
+        {% endfor %}
+    - port_bindings:
+        {% for port in etcd.docker.ports %}
+      - {{ port }}
+        {% endfor %}

--- a/etcd/docker/stopped.sls
+++ b/etcd/docker/stopped.sls
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+{% from "etcd/map.jinja" import etcd with context -%}
+
+etcd-check-docker-service-running:
+  service.running:
+    - name: docker
+    - require_in:
+      - docker_container: stop etcd dockerized service
+
+stop etcd dockerized service:
+  docker_container.stopped:
+    - name: run-etcd-dockerized-service

--- a/etcd/init.sls
+++ b/etcd/init.sls
@@ -3,12 +3,16 @@
 {% from "etcd/map.jinja" import etcd with context -%}
 
 include:
+     {% if etcd.docker.enabled %}
+  - etcd.docker.running
+
+     {% else %}
   - etcd.install
   - etcd.service
   - etcd.linuxenv
 
 extend:
-  etcd_{{ etcd.service }}_running:
+  etcd_{{ etcd.service_name }}_running:
     service:
       - listen:
            {% if etcd.use_upstream_repo|lower == 'homebrew' %}
@@ -23,3 +27,4 @@ extend:
         - archive: etcd-install
            {% endif %}
 
+     {% endif %}

--- a/etcd/map.jinja
+++ b/etcd/map.jinja
@@ -14,11 +14,13 @@
     base='etcd',
 ) %}
 
-# coreos release download values
+# coreos release package
 {% set pkg = "{0}-v{1}-{2}-{3}".format(etcd.pkg or 'etcd', etcd.version, etcd.os, etcd.arch) %} 
 {% do etcd.dl.update(
        { 'src_url': "{0}/v{1}/{2}.{3}".format(etcd.dl.base_uri, etcd.version, pkg, etcd.dl.format),
-         'archive_name': pkg + '.' + etcd.dl.format, 
-       })
-%}
+         'archive_name': pkg + '.' + etcd.dl.format, }) %}
 {% do etcd.update({ 'realhome': "{0}/{1}".format(etcd.prefix, pkg), 'pkg': pkg, }) %}
+
+# coreos release docker
+{% set args = " -name " ~ etcd.service.name ~ " -advertise-client-urls " ~ etcd.service.advertise_client_urls ~ " -listen-client-urls " ~ etcd.service.listen_client_urls ~ " -initial-advertise-peer-urls " ~ etcd.service.initial_advertise_peer_urls ~ " -listen-peer-urls " ~ etcd.service.listen_peer_urls ~ " -initial-cluster-token " ~ etcd.service.initial_cluster_token ~ " -initial-cluster " ~ etcd.service.initial_cluster ~ " -initial-cluster-state " ~ etcd.service.initial_cluster_state ~ " -data-dir " ~ etcd.service.data_dir  %}
+{% do etcd.docker.update({ 'cmd': "{0} {1}".format(etcd.command, args),}) %}

--- a/etcd/osmap.yaml
+++ b/etcd/osmap.yaml
@@ -1,28 +1,30 @@
 
 MacOS:
-  etcd:
-    os: 'darwin'
-    pkg:
-    src_hashsum:
-    src_hashurl:
-    manage_users: true
+  os: 'darwin'
+  pkg:
+  src_hashsum:
+  src_hashurl:
+  manage_users: true
   dl:
     format: zip
 
 Windows:
-  etcd:
-    bakdir: 'C:\\temp\\etcdbak\\'
-    command: 'etcd.exe'
-    datadir: 'C:\\Program files\\Coreos\\etcd\\data\\'
-    pkg:
-    prefix: 'C:\\Program files\\Coreos\\'
-    logdir: 'C:\\Program files\\Coreos\\etcd\\log\\'
-    manage_users: false
-    os: 'windows'
-    realhome:
-    src_hashsum:
-    src_hashurl:
-    symhome:
-    tmpdir: 'C:\\temp\\etcdtmp\\'
+  bakdir: 'C:\\temp\\etcdbak\\'
+  command: 'etcd.exe'
+  datadir: 'C:\\Program files\\Coreos\\etcd\\data\\'
+  pkg:
+  prefix: 'C:\\Program files\\Coreos\\'
+  logdir: 'C:\\Program files\\Coreos\\etcd\\log\\'
+  manage_users: false
+  os: 'windows'
+  realhome:
+  src_hashsum:
+  src_hashurl:
+  symhome:
+  tmpdir: 'C:\\temp\\etcdtmp\\'
   dl:
     format: zip
+
+CentOS:
+  docker:
+    packages: ['python-docker-py',]

--- a/etcd/service/health.sls
+++ b/etcd/service/health.sls
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+{% from "etcd/map.jinja" import etcd with context %}
+
+show etcd cluster health:
+  cmd.run:
+    - name: ./etcdctl cluster-health
+    - cwd: {{ opensds.realhome }}
+

--- a/etcd/service/init.sls
+++ b/etcd/service/init.sls
@@ -46,7 +46,7 @@ etcd-service:
     - context:
       etcd: {{ etcd|json }}
     - require_in:
-      - service:  etcd_{{ etcd.service_name }}_running
+      - service:  etcd_{{ etcd.service_name }}_running 
 
 {% endif %}
 

--- a/etcd/service/stopped.sls
+++ b/etcd/service/stopped.sls
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+{% from "etcd/map.jinja" import etcd with context %}
+
+etcd_{{ etcd.service_name }}_stopped:
+  service.dead:
+    - name: {{ etcd.service_name }}
+

--- a/pillar.example
+++ b/pillar.example
@@ -47,3 +47,17 @@ etcd:
   #dl:
     #base_uri: https://github.com/myfork/etcd/releases/download
 
+etcd:
+  version: 3.2.18
+  docker:
+    enabled: True
+    # If docker.enabled=True, defaults can be overridden here
+    version: latest
+    ports:
+      - 127.0.0.1:2379:2379
+      - 127.0.0.1:2380:2380
+      - 127.0.0.1:4001:4001
+    volumes:
+      - /usr/share/ca-certificates/:/etc/ssl/certs
+    stop_etcd_service_first: False
+    


### PR DESCRIPTION
This PR introduces support for dockerized etcd.  Docker is a de-facto standard for packaging micro-services and the`etcd.docker.running` and `etcd.docker.stopped` states are useful.   Complimented by "docker-formula" because you need to be sure Docker is installed.

I also moved `service.sls` to `./service/init.sls` to facilitate a new `service.stopped` state.

Note: the `etcd-docker-python-module.pip.installed` state includes `force_reinstall: True` as workaround for https://github.com/saltstack/salt/issues/48407

Tested on Ubuntu 16:04 and MacOS with Salt 2018.3

**Topfile**
```
base:
  '*':
    - docker
    - etcd.docker.running
    - etcd.docker.stopped
```
**States:**
```
          ID: pkgrepo dependencies
    Function: pkg.installed
        Name: python-apt
      Result: True
     Comment: All specified packages are already installed
     Started: 18:31:26.500735
    Duration: 796.633 ms
     Changes:   
----------
          ID: docker-dependencies-kernel
    Function: pkg.installed
      Result: True
     Comment: onlyif execution failed
     Started: 18:31:27.297750
    Duration: 690.78 ms
     Changes:   
----------
          ID: docker package dependencies
    Function: pkg.installed
      Result: True
     Comment: All specified packages are already installed
     Started: 18:31:27.989069
    Duration: 34.697 ms
     Changes:   
----------
          ID: purge old packages
    Function: pkgrepo.absent
        Name: deb https://get.docker.com/ubuntu docker main
      Result: True
     Comment: Package repo deb https://get.docker.com/ubuntu docker main is absent
     Started: 18:31:28.024144
    Duration: 70.911 ms
     Changes:   
----------
          ID: purge old packages
    Function: pkg.purged
      Result: True
     Comment: All specified packages are already absent
     Started: 18:31:28.095428
    Duration: 89.242 ms
     Changes:   
----------
          ID: docker package repository
    Function: pkgrepo.managed
        Name: deb https://apt.dockerproject.org/repo ubuntu-xenial main
      Result: True
     Comment: Package repo 'deb https://apt.dockerproject.org/repo ubuntu-xenial main' already configured
     Started: 18:31:28.185371
    Duration: 58.699 ms
     Changes:   
----------
          ID: docker package
    Function: pkg.installed
        Name: docker-engine
      Result: True
     Comment: All specified packages are already installed
     Started: 18:31:28.245531
    Duration: 11.661 ms
     Changes:   
----------
          ID: docker-config
    Function: file.managed
        Name: /etc/default/docker
      Result: True
     Comment: File /etc/default/docker is in the correct state
     Started: 18:31:28.257768
    Duration: 86.687 ms
     Changes:   
----------
          ID: docker-service
    Function: service.running
        Name: docker
      Result: True
     Comment: The service docker is already running
     Started: 18:31:28.345333
    Duration: 47.351 ms
     Changes:   
----------
          ID: etcd_etcd_stopped
    Function: service.dead
        Name: etcd
      Result: True
     Comment: The service etcd is already dead
     Started: 18:31:28.393119
    Duration: 36.913 ms
     Changes:   
----------
          ID: etcd-docker-python-module
    Function: pip.installed
        Name: docker
      Result: True
     Comment: All packages were successfully installed
     Started: 18:31:28.430484
    Duration: 5026.469 ms
     Changes:   
              ----------
              docker==3.1.1:
                  Installed
----------
          ID: etcd-ensure-docker-service
    Function: service.running
        Name: docker
      Result: True
     Comment: The service docker is already running
     Started: 18:31:34.077674
    Duration: 29.403 ms
     Changes:   
----------
          ID: run-etcd-dockerized-service
    Function: docker_container.running
      Result: True
     Comment: Container 'run-etcd-dockerized-service' is already configured as specified. State changed from 'stopped' to 'running'.
     Started: 18:31:34.109809
    Duration: 859.49 ms
     Changes:   
              ----------
              state:
                  ----------
                  new:
                      running
                  old:
                      stopped
----------
          ID: stop etcd dockerized service
    Function: docker_container.stopped
        Name: run-etcd-dockerized-service
      Result: True
     Comment: The following container(s) were stopped: run-etcd-dockerized-service
     Started: 18:31:34.969792
    Duration: 385.327 ms
     Changes:   
              ----------
              run-etcd-dockerized-service:
                  ----------
                  result:
                      True
                  state:
                      ----------
                      new:
                          stopped
                      old:
                          running

Summary for local
-------------
Succeeded: 14 (changed=3)
Failed:     0
-------------
Total states run:     14
Total run time:    8.224 s
```