### PR TITLE
Fix pillar.example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,9 +39,15 @@ Ensure the `etcd` service is stopped on minion.
 
 ``etcd.docker.running``
 ------------
-Ensure that an `etcd` container with a specific configuration is present and running. Includes the `etcd.service.stopped` state by default.
+Ensure that an `etcd` container with a specific configuration is present and running. Requires Docker to be running - you could run ``docker`` state from ``docker-formula`` to ensure this requirement.
 
-.. note:: Requires Docker! Running the `docker` state from the "docker-formula" satisfies this requirement.
+State top file::
+
+        base:
+          '*':
+            - docker                  #saltstack-formulas/docker-formula
+            - etcd.docker.running     #saltstack-formulas/etcd-formula
+
 
 ``etcd.docker.stopped``
 ------------

--- a/pillar.example
+++ b/pillar.example
@@ -47,11 +47,10 @@ etcd:
   #dl:
     #base_uri: https://github.com/myfork/etcd/releases/download
 
-etcd:
-  version: 3.2.18
   docker:
     enabled: True
     # If docker.enabled=True, defaults can be overridden here
+    image: quay.io/coreos/etcd
     version: latest
     ports:
       - 127.0.0.1:2379:2379


### PR DESCRIPTION
The etcd dictname and etcd.version variable appear twice in pillar.example. Fixed.