### PR TITLE
Wrap yaml vars in quotes

### DIFF
--- a/etcd/defaults.yaml
+++ b/etcd/defaults.yaml
@@ -43,24 +43,24 @@ etcd:
     version: latest
     network_mode: host
     ports:
-      - 127.0.0.1:2379:2379
-      - 127.0.0.1:2380:2380
+      - '127.0.0.1:2379:2379'
+      - '127.0.0.1:2380:2380'
     volumes:
       - /usr/share/ca-certificates/:/etc/ssl/certs
-    stop_etcd_service_first: true
+    stop_local_etcd_service_first: true
 
   service:
     #defaults for linux
     name: etcd0
-    #etcd_endpoints:
+    etcd_endpoints: 'https://127.0.0.1:2379,https://127.0.0.1:2380'
     data_dir: /var/lib/etcd/etcd0
-    initial_cluster: etcd0=https://127.0.0.1:2380
+    initial_cluster: 'etcd0=https://127.0.0.1:2380'
     initial_cluster_state: new
     initial_cluster_token: etcd-cluster-1
-    initial_advertise_peer_urls: https://127.0.0.1:2380
-    listen_peer_urls: https://127.0.0.1:2380
-    listen_client_urls: https://127.0.0.1:2379
-    advertise_client_urls: https://127.0.0.1:2379
+    initial_advertise_peer_urls: 'https://127.0.0.1:2380'
+    listen_peer_urls: 'https://127.0.0.1:2380'
+    listen_client_urls: 'https://127.0.0.1:2379'
+    advertise_client_urls: 'https://127.0.0.1:2379'
     #etcd can be configured to automatically generate its keys. On initialization,
     #each member creates its own set of keys based on its advertised IP addresses and hosts.
     auto_tls: '"true"'
@@ -69,8 +69,8 @@ etcd:
   etcdctl:
     api: 3
     discovery_srv:
-    peers: https://127.0.0.1:2379
-    endpoint: https://127.0.0.1:2379
+    peers: 'https://127.0.0.1:2379'
+    endpoint: 'https://127.0.0.1:2379'
     cert_file:
     key_file:
     ca_file:

--- a/etcd/docker/running.sls
+++ b/etcd/docker/running.sls
@@ -2,7 +2,7 @@
 # vim: ft=yaml
 {% from "etcd/map.jinja" import etcd with context -%}
 
-   {% if etcd.docker.stop_etcd_service_first %}
+   {% if etcd.docker.stop_local_etcd_service_first %}
 include:
   - etcd.service.stopped
    {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -12,14 +12,14 @@ etcd:
   service:
     name: etcd0
     data_dir: /var/lib/etcd/etcd0
-    #etcd_endpoints: https://etcd01:2379,https://etcd02:2379,https://etcd03:2379
-    initial_cluster: etcd0=https://0.0.0.0:2380
+    #etcd_endpoints: 'https://etcd01:2379,https://etcd02:2379,https://etcd03:2379'
+    initial_cluster: 'etcd0=https://0.0.0.0:2380'
     initial_cluster_state: new
     initial_cluster_token: etcd-cluster-1
-    initial_advertise_peer_urls: https://0.0.0.0:2380
-    listen_peer_urls: https://0.0.0.0:2380
-    listen_client_urls: https://0.0.0.0:2379
-    advertise_client_urls: https://0.0.0.0:2379
+    initial_advertise_peer_urls: 'https://0.0.0.0:2380'
+    listen_peer_urls: 'https://0.0.0.0:2380'
+    listen_client_urls: 'https://0.0.0.0:2379'
+    advertise_client_urls: 'https://0.0.0.0:2379'
 
     ##Security https://coreos.com/etcd/docs/latest/op-guide/security.html
     cert_file: /etc/ssl/etcd/ca.pem
@@ -31,8 +31,8 @@ etcd:
   etcdctl:
     api: 2
     #discovery_srv: example.com
-    peers: https://0.0.0.0:2379
-    endpoint: https://0.0.0.0:2379
+    peers: 'https://0.0.0.0:2379'
+    endpoint: 'https://0.0.0.0:2379'
     cert_file:
     key_file:
     ca_file:
@@ -45,18 +45,18 @@ etcd:
     #altpriority: {{ range(1, 90000) | random }}
 
   #dl:
-    #base_uri: https://github.com/myfork/etcd/releases/download
+    #base_uri: 'https://github.com/myfork/etcd/releases/download'
 
   docker:
     enabled: True
-    # If docker.enabled=True, defaults can be overridden here
+    # If docker_enabled=True, defaults can be overridden here
     image: quay.io/coreos/etcd
     version: latest
     ports:
-      - 127.0.0.1:2379:2379
-      - 127.0.0.1:2380:2380
-      - 127.0.0.1:4001:4001
+      - '127.0.0.1:2379:2379'
+      - '127.0.0.1:2380:2380'
+      - '127.0.0.1:4001:4001'
     volumes:
       - /usr/share/ca-certificates/:/etc/ssl/certs
-    stop_etcd_service_first: False
+    stop_local_etcd_service_first: False
     


### PR DESCRIPTION
Minor update

- Wrap repeating ':' in quotes (just in case of https://pyyaml.org/wiki/YAMLColonInFlowContext)
- rename `stop_etcd_service_first` to `stop_local_etcd_service_first` variable
- Add `etcd_endpoints` default variable/value
