### PR TITLE
Fix osmap.yaml for RedHat

### DIFF
--- a/etcd/osmap.yaml
+++ b/etcd/osmap.yaml
@@ -27,4 +27,4 @@ Windows:
 
 CentOS:
   docker:
-    packages: ['python-docker-py',]
+    packages: ['python2-docker',]


### PR DESCRIPTION
PR to fix osmap.yaml on RedHat (see https://github.com/saltstack-formulas/opensds-formula/issues/1)

Package python-docker-py is obsoleted by python2-docker on CENT7