### PR TITLE
Configure docker exposed ports

### DIFF
--- a/etcd/defaults.yaml
+++ b/etcd/defaults.yaml
@@ -37,19 +37,20 @@ etcd:
     unpack_opts: --strip-components=1
 
   docker:
+    skip_translate: None
     packages: ['python-docker', 'python3-docker',]
     enabled: false
     image: gcr.io/etcd-development/etcd
     version: v3.2.24
     network_mode: host
     ports:
-      - 'tcp/2379'
-      - 'tcp/2380'
-      - 'udp/2379'
-      - 'udp/2380'
+      - 2379
+      - 2380
+      - 2379/udp
+      - 2380/udp
     port_bindings:
-      - '127.0.0.1:2379:2379'
-      - '127.0.0.1:2380:2380'
+      - 0.0.0.0:2379:2379
+      - 0.0.0.0:2380:2380
     volumes:
       - /usr/share/ca-certificates/:/etc/ssl/certs
     stop_local_etcd_service_first: true

--- a/etcd/defaults.yaml
+++ b/etcd/defaults.yaml
@@ -43,6 +43,11 @@ etcd:
     version: v3.2.24
     network_mode: host
     ports:
+      - 'tcp/2379'
+      - 'tcp/2380'
+      - 'udp/2379'
+      - 'udp/2380'
+    port_bindings:
       - '127.0.0.1:2379:2379'
       - '127.0.0.1:2380:2380'
     volumes:

--- a/etcd/defaults.yaml
+++ b/etcd/defaults.yaml
@@ -43,6 +43,10 @@ etcd:
     image: gcr.io/etcd-development/etcd
     version: v3.2.24
     network_mode: host
+    cmd_args: '--auto-tls --peer-auto-tls'
+    #environment:
+    #  - ETCD_AUTO_TLS: True
+    #  - ETCD_PEER_AUTO_TLS: True
     ports:
       - 2379
       - 2380

--- a/etcd/docker/running.sls
+++ b/etcd/docker/running.sls
@@ -47,6 +47,7 @@ etcd-ensure-docker-service:
 
 run-etcd-dockerized-service:
   docker_container.running:
+    - skip_translate: {{ etcd.docker.skip_translate }}
        {% if etcd.docker.version %}
     - image: {{ etcd.docker.image }}:{{ etcd.docker.version }}
        {% else %}
@@ -54,9 +55,11 @@ run-etcd-dockerized-service:
        {% endif %}
     - command: {{ etcd.docker.cmd }}
     - binds:
-        {% for volume in etcd.docker.volumes %}
+        {%- if "volumes" in etcd.docker %}
+          {% for volume in etcd.docker.volumes %}
       - {{ volume }}
-        {% endfor %}
+          {% endfor %}
+        {%- endif %}
     - ports:
         {% for port in etcd.docker.ports %}
       - {{ port }}

--- a/etcd/docker/running.sls
+++ b/etcd/docker/running.sls
@@ -54,8 +54,14 @@ run-etcd-dockerized-service:
     - image: {{ etcd.docker.image }}
        {% endif %}
     - command: {{ etcd.docker.cmd }}
-    - binds:
+        {%- if "environment" in etcd.docker %}
+    - environment:
+          {%- for k,v in etcd.docker.environment %}
+      - {{ k|upper }}: {{ v }}
+          {% endfor %}
+        {%- endif %}
         {%- if "volumes" in etcd.docker %}
+    - binds:
           {% for volume in etcd.docker.volumes %}
       - {{ volume }}
           {% endfor %}

--- a/etcd/docker/running.sls
+++ b/etcd/docker/running.sls
@@ -57,7 +57,11 @@ run-etcd-dockerized-service:
         {% for volume in etcd.docker.volumes %}
       - {{ volume }}
         {% endfor %}
-    - port_bindings:
+    - ports:
         {% for port in etcd.docker.ports %}
       - {{ port }}
+        {% endfor %}
+    - port_bindings:
+        {% for porty in etcd.docker.port_bindings %}
+      - {{ porty }}
         {% endfor %}

--- a/etcd/map.jinja
+++ b/etcd/map.jinja
@@ -22,5 +22,5 @@
 {% do etcd.update({ 'realhome': "{0}/{1}".format(etcd.prefix, pkg), 'pkg': pkg, }) %}
 
 # coreos release docker
-{% set args = " -name " ~ etcd.service.name ~ " -advertise-client-urls " ~ etcd.service.advertise_client_urls ~ " -listen-client-urls " ~ etcd.service.listen_client_urls ~ " -initial-advertise-peer-urls " ~ etcd.service.initial_advertise_peer_urls ~ " -listen-peer-urls " ~ etcd.service.listen_peer_urls ~ " -initial-cluster-token " ~ etcd.service.initial_cluster_token ~ " -initial-cluster " ~ etcd.service.initial_cluster ~ " -initial-cluster-state " ~ etcd.service.initial_cluster_state ~ " -data-dir " ~ etcd.service.data_dir  %}
+{% set args = " -name " ~ etcd.service.name ~ " -advertise-client-urls " ~ etcd.service.advertise_client_urls ~ " -listen-client-urls " ~ etcd.service.listen_client_urls ~ " -initial-advertise-peer-urls " ~ etcd.service.initial_advertise_peer_urls ~ " -listen-peer-urls " ~ etcd.service.listen_peer_urls ~ " -initial-cluster-token " ~ etcd.service.initial_cluster_token ~ " -initial-cluster " ~ etcd.service.initial_cluster ~ " -initial-cluster-state " ~ etcd.service.initial_cluster_state ~ " -data-dir " ~ etcd.service.data_dir ~ " " ~ etcd.docker.cmd_args %}
 {% do etcd.docker.update({ 'cmd': "{0} {1}".format(etcd.command, args),}) %}

--- a/pillar.example
+++ b/pillar.example
@@ -54,6 +54,10 @@ etcd:
     image: quay.io/coreos/etcd
     version: latest
     skip_translate: True
+    cmd_args: ''
+    environment:
+      - ETCD_AUTO_TLS: False
+      - ETCD_PEER_AUTO_TLS: False
     ports:
       - 2379
       - 2380

--- a/pillar.example
+++ b/pillar.example
@@ -54,9 +54,13 @@ etcd:
     image: quay.io/coreos/etcd
     version: latest
     ports:
+      - 'tcp/2379'
+      - 'tcp/2380'
+      - 'udp/2379'
+      - 'udp/2380'
+    port_bindings:
       - '127.0.0.1:2379:2379'
       - '127.0.0.1:2380:2380'
-      - '127.0.0.1:4001:4001'
     volumes:
       - /usr/share/ca-certificates/:/etc/ssl/certs
     stop_local_etcd_service_first: False

--- a/pillar.example
+++ b/pillar.example
@@ -53,14 +53,15 @@ etcd:
     # If docker_enabled=True, defaults can be overridden here
     image: quay.io/coreos/etcd
     version: latest
+    skip_translate: True
     ports:
-      - 'tcp/2379'
-      - 'tcp/2380'
-      - 'udp/2379'
-      - 'udp/2380'
+      - 2379
+      - 2380
+      - 2379/udp
+      - 2380/udp
     port_bindings:
-      - '127.0.0.1:2379:2379'
-      - '127.0.0.1:2380:2380'
+      - 0.0.0.0:2379:2379
+      - 0.0.0.0:2380:2380
     volumes:
       - /usr/share/ca-certificates/:/etc/ssl/certs
     stop_local_etcd_service_first: False


### PR DESCRIPTION
This PR exposes etcd ports to outside docker host.  Add `skip_translate: <value>` pillar support.

And etcd will not start inside container if certs are not passed as volumes. 
```
etcdmain: cannot listen on TLS for 127.0.0.1:2380: KeyFile and CertFile are not presented
```
To fix this, the PR passes AUTO_TLS parameters to container as default pillar.