### PR TITLE
Add container_name parameter

### DIFF
--- a/etcd/defaults.yaml
+++ b/etcd/defaults.yaml
@@ -38,8 +38,9 @@ etcd:
 
   docker:
     skip_translate: None
-    packages: ['python-docker', 'python3-docker',]
+    packages: []
     enabled: false
+    container_name: etcd-docker-svc
     image: gcr.io/etcd-development/etcd
     version: v3.2.24
     network_mode: host

--- a/etcd/docker/running.sls
+++ b/etcd/docker/running.sls
@@ -16,8 +16,9 @@ etcd-docker-compose-request-conflict-resolution:
     - reload_modules: True
     - onlyif: {{ grains.os_family == 'RedHat' }}
 
-{% for pkg in etcd.docker.packages -%}
-  {% if pkg %}
+{%- if etcd.docker.packages %}
+  {% for pkg in etcd.docker.packages -%}
+
 etcd-docker-{{ pkg }}-package:
   pkg.installed:
     - name:  {{ pkg }}
@@ -27,8 +28,9 @@ etcd-docker-{{ pkg }}-package:
       - docker_container: run-etcd-dockerized-service
     - onfail_in:
       - pip: etcd-docker-python-pip-install
-  {% endif %}
-{% endfor %}
+
+  {% endfor %}
+{% endif %}
 
 etcd-docker-python-pip-install:
   pip.installed:
@@ -47,6 +49,7 @@ etcd-ensure-docker-service:
 
 run-etcd-dockerized-service:
   docker_container.running:
+    - name: {{ etcd.docker.container_name }}
     - skip_translate: {{ etcd.docker.skip_translate }}
        {% if etcd.docker.version %}
     - image: {{ etcd.docker.image }}:{{ etcd.docker.version }}

--- a/etcd/osmap.yaml
+++ b/etcd/osmap.yaml
@@ -25,6 +25,11 @@ Windows:
   dl:
     format: zip
 
-CentOS:
+### https://github.com/saltstack-formulas/etcd-formula/issues/26
+#CentOS:
+# docker:
+### packages: ['python2-docker',]
+
+Ubuntu:
   docker:
-    packages: ['python2-docker',]
+    packages: ['python-docker', python3-docker',]


### PR DESCRIPTION
This PR assigns a more meaningful container name instead of salt using state ID.

This PR should resolve #26 because installing python2-docker causes [pip conflict issue.](https://bugzilla.redhat.com/show_bug.cgi?id=1187057)