### PR TITLE
Use official coreos image

### DIFF
--- a/etcd/defaults.yaml
+++ b/etcd/defaults.yaml
@@ -41,8 +41,8 @@ etcd:
     packages: []
     enabled: false
     container_name: etcd-docker-svc
-    image: quay.io/coreos/etcd:latest
-    version: v3.2.24
+    image: quay.io/coreos/etcd
+    version: latest   {# > v3.2.24 #}
     network_mode: host
     cmd_args: '--auto-tls --peer-auto-tls'
     #environment:

--- a/etcd/defaults.yaml
+++ b/etcd/defaults.yaml
@@ -41,7 +41,7 @@ etcd:
     packages: []
     enabled: false
     container_name: etcd-docker-svc
-    image: gcr.io/etcd-development/etcd
+    image: quay.io/coreos/etcd:latest
     version: v3.2.24
     network_mode: host
     cmd_args: '--auto-tls --peer-auto-tls'

--- a/etcd/docker/running.sls
+++ b/etcd/docker/running.sls
@@ -51,11 +51,9 @@ run-etcd-dockerized-service:
   docker_container.running:
     - name: {{ etcd.docker.container_name }}
     - skip_translate: {{ etcd.docker.skip_translate }}
-       {% if etcd.docker.version %}
     - image: {{ etcd.docker.image }}:{{ etcd.docker.version }}
-       {% else %}
-    - image: {{ etcd.docker.image }}
-       {% endif %}
+    - restart_policy: always
+    - network_mode: host
     - command: {{ etcd.docker.cmd }}
         {%- if "environment" in etcd.docker %}
     - environment:

--- a/pillar.example
+++ b/pillar.example
@@ -51,7 +51,8 @@ etcd:
   docker:
     enabled: True
     # If docker_enabled=True, defaults can be overridden here
-    image: quay.io/coreos/etcd
+    ###image: quay.io/coreos/etcd
+    ###image: gcr.io/etcd-development/etcd
     version: latest
     skip_translate: True
     cmd_args: ''


### PR DESCRIPTION
This PR uses official coreos image instead of google cloud developer image.