### PR TITLE
Fix conflicting IDs on Ubuntu

### DIFF
--- a/etcd/osmap.yaml
+++ b/etcd/osmap.yaml
@@ -32,4 +32,4 @@ Windows:
 
 Ubuntu:
   docker:
-    packages: ['python-docker', python3-docker',]
+    packages: ['python-docker', 'python3-docker',]


### PR DESCRIPTION
This PR fixes regression on Ubuntu from recent Centos updates.  

Specifically Jinja rendering is failing due to conflicting IDs on Ubuntu.
```
    Data failed to compile:
----------
    Rendering SLS 'base:etcd.docker.running' failed: while constructing a mapping
  in "<unicode string>", line 10, column 3:
      pip.installed:
      ^
found conflicting ID 'pkg.installed'
  in "<unicode string>", line 27, column 3:
      pkg.installed:
      ^
```