### PR TITLE
move cmd_args parameter to etcd.service dict

### DIFF
--- a/etcd/defaults.yaml
+++ b/etcd/defaults.yaml
@@ -63,6 +63,7 @@ etcd:
   service:
     #defaults for linux
     name: etcd0
+    # not supported #endpoints: 'https://127.0.0.1:2379,https://127.0.0.1:2380'
     data_dir: /var/lib/etcd/etcd0
     initial_cluster: 'etcd0=https://127.0.0.1:2380'
     initial_cluster_state: new
@@ -73,10 +74,9 @@ etcd:
     advertise_client_urls: 'https://127.0.0.1:2379'
     ##etcd can be configured to automatically generate its keys. On initialization,
     ##each member creates its own set of keys based on its advertised IP addresses and hosts.
-    cmd_args: '--auto-tls --peer-auto-tls'
     auto-tls: True
     peer-auto-tls: True
-    #insecure-skip-verify-tls: True ##See also https://github.com/etcd-io/etcd/issues/7930
+    cmd_args: '--auto-tls --peer-auto-tls'
 
   etcdctl:
     api: 3

--- a/etcd/defaults.yaml
+++ b/etcd/defaults.yaml
@@ -44,7 +44,6 @@ etcd:
     image: quay.io/coreos/etcd
     version: latest   {# > v3.2.24 #}
     network_mode: host
-    cmd_args: '--auto-tls --peer-auto-tls'
     #environment:
     #  - ETCD_AUTO_TLS: True
     #  - ETCD_PEER_AUTO_TLS: True
@@ -64,7 +63,6 @@ etcd:
   service:
     #defaults for linux
     name: etcd0
-    # not supported #endpoints: 'https://127.0.0.1:2379,https://127.0.0.1:2380'
     data_dir: /var/lib/etcd/etcd0
     initial_cluster: 'etcd0=https://127.0.0.1:2380'
     initial_cluster_state: new
@@ -75,6 +73,7 @@ etcd:
     advertise_client_urls: 'https://127.0.0.1:2379'
     ##etcd can be configured to automatically generate its keys. On initialization,
     ##each member creates its own set of keys based on its advertised IP addresses and hosts.
+    cmd_args: '--auto-tls --peer-auto-tls'
     auto-tls: True
     peer-auto-tls: True
     #insecure-skip-verify-tls: True ##See also https://github.com/etcd-io/etcd/issues/7930

--- a/etcd/map.jinja
+++ b/etcd/map.jinja
@@ -22,5 +22,5 @@
 {% do etcd.update({ 'realhome': "{0}/{1}".format(etcd.prefix, pkg), 'pkg': pkg, }) %}
 
 # coreos release docker
-{% set args = " -name " ~ etcd.service.name ~ " -advertise-client-urls " ~ etcd.service.advertise_client_urls ~ " -listen-client-urls " ~ etcd.service.listen_client_urls ~ " -initial-advertise-peer-urls " ~ etcd.service.initial_advertise_peer_urls ~ " -listen-peer-urls " ~ etcd.service.listen_peer_urls ~ " -initial-cluster-token " ~ etcd.service.initial_cluster_token ~ " -initial-cluster " ~ etcd.service.initial_cluster ~ " -initial-cluster-state " ~ etcd.service.initial_cluster_state ~ " -data-dir " ~ etcd.service.data_dir ~ " " ~ etcd.docker.cmd_args %}
+{% set args = " -name " ~ etcd.service.name ~ " -advertise-client-urls " ~ etcd.service.advertise_client_urls ~ " -listen-client-urls " ~ etcd.service.listen_client_urls ~ " -initial-advertise-peer-urls " ~ etcd.service.initial_advertise_peer_urls ~ " -listen-peer-urls " ~ etcd.service.listen_peer_urls ~ " -initial-cluster-token " ~ etcd.service.initial_cluster_token ~ " -initial-cluster " ~ etcd.service.initial_cluster ~ " -initial-cluster-state " ~ etcd.service.initial_cluster_state ~ " -data-dir " ~ etcd.service.data_dir ~ " " ~ etcd.service.cmd_args %}
 {% do etcd.docker.update({ 'cmd': "{0} {1}".format(etcd.command, args),}) %}

--- a/pillar.example
+++ b/pillar.example
@@ -12,7 +12,6 @@ etcd:
   service:
     name: etcd0
     data_dir: /var/lib/etcd/etcd0
-    #etcd_endpoints: 'https://etcd01:2379,https://etcd02:2379,https://etcd03:2379'
     initial_cluster: 'etcd0=https://0.0.0.0:2380'
     initial_cluster_state: new
     initial_cluster_token: etcd-cluster-1
@@ -25,9 +24,10 @@ etcd:
     cert_file: /etc/ssl/etcd/ca.pem
     key_file: /etc/ssl/etcd/client.pem
     ca_file: /etc/ssl/etcd/client-key.pem
+
+    cmd_args: ''
     auto_tls: False
     peer_auto_tls: False
-    insecure-skip-verify-tls: False
 
   etcdctl:
     api: 2
@@ -55,7 +55,6 @@ etcd:
     ###image: gcr.io/etcd-development/etcd
     version: latest
     skip_translate: True
-    cmd_args: ''
     environment:
       - ETCD_AUTO_TLS: False
       - ETCD_PEER_AUTO_TLS: False


### PR DESCRIPTION
This PR fixes inconsistency - `cmd_args` parameter should exist under `service` dict not `docker` dict.  Also removed some unused params.