### PR TITLE
Allow etcd binary install only

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Metastate for all the software and service deployment states.
 
 ``etcd.install``
 ------------
-Installs etcd version by downloading the archive from github and extracting it to the {{ etcd.prefix }} directory.
+Installs etcd version by downloading the archive from github and extracting it to the {{ etcd.prefix }} directory. Includes `etcd.service` by default (unless `etcd.docker.enabled` is True).
 
 ``etcd.linuxenv``
 ------------

--- a/etcd/init.sls
+++ b/etcd/init.sls
@@ -3,13 +3,12 @@
 {% from "etcd/map.jinja" import etcd with context -%}
 
 include:
+  - etcd.install
+  - etcd.linuxenv
      {% if etcd.docker.enabled %}
   - etcd.docker.running
-
-     {% else %}
-  - etcd.install
+     {%- else %}
   - etcd.service
-  - etcd.linuxenv
 
 extend:
   etcd_{{ etcd.service_name }}_running:

--- a/etcd/install.sls
+++ b/etcd/install.sls
@@ -2,8 +2,10 @@
 # vim: ft=yaml
 {% from "etcd/map.jinja" import etcd with context -%}
 
+  {%- if not etcd.docker.enabled %}
 include:
   - etcd.service
+  {%- endif %}
 
   {%- if etcd.manage_users %}
 etcd-user-group-home:
@@ -64,7 +66,9 @@ etcd-user-envfile:
       etcd: {{ etcd|json }}
     - require_in:
       - cmd: etcd-download-archive
+  {%- if not etcd.docker.enabled %}
       - service: etcd_{{ etcd.service_name }}_running
+  {%- endif %}
 
   {%- endif %}
 
@@ -103,8 +107,10 @@ etcd-install:
     - name: '{{ etcd.prefix }}'
     - archive_format: {{ etcd.dl.format.split('.')[0] }}
     - unless: test -f {{ etcd.realhome }}{{ etcd.command }}
+  {%- if not etcd.docker.enabled %}
     - watch_in:
       - service: etcd_{{ etcd.service_name }}_running
+  {%- endif %}
     - onchanges:
       - cmd: etcd-download-archive
     {%- if etcd.src_hashurl and grains['saltversioninfo'] > [2016, 11, 6] %}


### PR DESCRIPTION
This is a workaround for #33 reusing `docker.container.enabled` boolean. 

So when you want etcd docker container running - thats fine - you get etcdctl client too.