### PR TITLE
remove dangling unless & workaround python3 pip issues

### DIFF
--- a/etcd/docker/running.sls
+++ b/etcd/docker/running.sls
@@ -22,16 +22,21 @@ etcd-docker-{{ pkg }}-package:
 {% endif %}
 
 etcd-docker-python-modules-install:
+       {%- if grains.os_family in ('Suse',) %}  ##workaround https://github.com/saltstack-formulas/docker-formula/issues/198
+  cmd.run:
+    - name: /usr/bin/pip install docker
+       {%- else %}
   pip.installed:
     - names:
       - docker
-    {%- if grains.os_family == 'RedHat' %}
-       {# https://github.com/saltstack-formulas/etcd-formula/issues/19  #}
+            {%- if grains.os_family == 'RedHat' %}
+               {# https://github.com/saltstack-formulas/etcd-formula/issues/19  #}
       - requests {{ etcd.docker.pip_requests_version_wanted }}
-    {%- endif %}
+            {%- endif %}
     - reload_modules: True
     - exists_action: i
     - force_reinstall: False
+        {%- endif %}
     - require_in:
       - docker_container: run-etcd-dockerized-service
 

--- a/etcd/install.sls
+++ b/etcd/install.sls
@@ -76,7 +76,6 @@ etcd-download-archive:
         interval: {{ etcd.dl.interval }}
         until: True
         splay: 10
-    - unless: test -f {{ etcd.realhome }}/{{ etcd.command }}
     {%- endif %}
 
     {%- if etcd.src_hashsum and grains['saltversioninfo'] <= [2016, 11, 6] %}

--- a/etcd/install.sls
+++ b/etcd/install.sls
@@ -68,8 +68,8 @@ etcd-user-envfile:
 
 etcd-download-archive:
   cmd.run:
-    - name: curl {{ etcd.dl.opts }} -o {{ etcd.tmpdir }}{{ etcd.dl.archive_name }} {{ etcd.dl.src_url }}
-    - unless: test -f {{ etcd.tmpdir }}{{ etcd.dl.archive_name }}
+    - name: curl {{ etcd.dl.opts }} -o {{ etcd.tmpdir }}/{{ etcd.dl.archive_name }} {{ etcd.dl.src_url }}
+    - unless: test -f {{ etcd.tmpdir }}/{{ etcd.dl.archive_name }}
     {%- if grains['saltversioninfo'] >= [2017, 7, 0] %}
     - retry:
         attempts: {{ etcd.dl.retries }}


### PR DESCRIPTION
This PR fixes issue where `etcd.download-archive` state has two unless conditions.  

If the tarfile does not exist then `etcd-check-archive-hash` state fails - we need the tarball!!


UPDATE:
This PR also works around broken pip states when python3 is OS default (Suse 15.0).
See: https://github.com/saltstack-formulas/docker-formula/issues/198